### PR TITLE
update：适配python3.12

### DIFF
--- a/pjstealth/stealth.py
+++ b/pjstealth/stealth.py
@@ -5,12 +5,20 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Dict
 from .env_data import env_data
-import pkg_resources
+import platform
 
 
-def from_file(name):
-    """Read script from ./js directory"""
-    return pkg_resources.resource_string('pjstealth', f'feature/{name}').decode()
+if platform.python_version() < "3.12":
+    import pkg_resources
+    def from_file(name):
+        """Read script from ./js directory for python3.11 or before"""
+        return pkg_resources.resource_string('pjstealth', f'feature/{name}').decode()
+
+else:
+    from importlib.resources import files 
+    def from_file(name):
+        """Read script form ./js directory for python3.12 or later"""
+        return files('pjstealth').joinpath(f'feature/{name}').read_text(encoding='utf-8')
 
 
 SCRIPTS: Dict[str, str] = {


### PR DESCRIPTION
由于pkg_resources在python3.12已遭到弃用，被importlib.resources代替。故该段代码在3.12或以后的python解释器运行会报错。详见:https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-string